### PR TITLE
Proper segretation between Server and Client in networking/ModMessages

### DIFF
--- a/src/main/java/dev/thestaticvoid/solar_panels/networking/ModMessages.java
+++ b/src/main/java/dev/thestaticvoid/solar_panels/networking/ModMessages.java
@@ -3,6 +3,8 @@ package dev.thestaticvoid.solar_panels.networking;
 import dev.thestaticvoid.solar_panels.SolarPanels;
 import dev.thestaticvoid.solar_panels.util.ResourceIdentifier;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
+import net.fabricmc.loader.api.FabricLoader;
+import net.fabricmc.api.EnvType;
 
 public class ModMessages {
     public static final ResourceIdentifier ENERGY_AMOUNT_SYNC = new ResourceIdentifier("energy_amount_sync");

--- a/src/main/java/dev/thestaticvoid/solar_panels/networking/ModMessages.java
+++ b/src/main/java/dev/thestaticvoid/solar_panels/networking/ModMessages.java
@@ -8,9 +8,11 @@ public class ModMessages {
     public static final ResourceIdentifier ENERGY_AMOUNT_SYNC = new ResourceIdentifier("energy_amount_sync");
     public static void initialize() {
         SolarPanels.LOGGER.debug("Initializing packets for " + SolarPanels.MOD_ID);
-
-        registerC2SPackets();
-        registerS2CPackets();
+        if (FabricLoader.getInstance().getEnvironmentType() == EnvType.SERVER) {
+            registerC2SPackets();
+        }else {
+            registerS2CPackets();
+        }
     }
 
     private static void registerC2SPackets() {


### PR DESCRIPTION
Fixes issue #3, where the server crashes due to attempting to load a client class on the server.